### PR TITLE
Add ReadTheDocs config and PR comment automation

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -1,0 +1,27 @@
+# The ReadTheDocs preview link is "hidden" within the GitHub "Checks"
+# interface. For users who don't know this, finding the preview link may be
+# very difficult or frustrating. This workflow makes the link more
+# findable by updating PR descriptions to include it.
+name: 'Add ReadTheDocs preview link to PR description'
+
+on:
+  pull_request_target:
+    types:
+      - 'opened'
+
+permissions:
+  pull-requests: 'write'
+
+jobs:
+  autolink-rtd-previews:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333'  # v1.5
+        with:
+          project-slug: 'geojupyter-initiatives'
+          single-version: true
+          single-language: true
+          message-template: |
+            ---
+            :mag: Preview: {docs-pr-index-url}
+            _Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# For this project, we use ReadTheDocs only for Pull Request previews. GitHub
+# pages currently hosts the actual website.
+version: 2
+
+
+build:
+  os: "ubuntu-lts-latest"
+
+  commands:
+    - "asdf plugin add pixi"
+    - "asdf install pixi latest"
+    - "asdf global pixi latest"
+
+    - "pixi run render"
+    - "mkdir --parents $READTHEDOCS_OUTPUT/html/"
+    - "mv _build/html/* $READTHEDOCS_OUTPUT/html/."
+    - "rm -rf _build"  # RTD build fails if _build/html is detected :(


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-initiatives start -->
---
:mag: Preview: https://geojupyter-initiatives--39.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-initiatives end -->