### PR TITLE
Add github user mentions plugin

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -6,3 +6,8 @@ blockquote {
   font-weight: default;
   font-style: normal !important;
 }
+
+/* Workaround for not being able to do this in the plugin itself */
+.dark .github-mention-icon {
+  filter: invert(1);
+}

--- a/initiatives/002-geospatial-information-agents/index.md
+++ b/initiatives/002-geospatial-information-agents/index.md
@@ -13,22 +13,30 @@ github_issue_number: 14
 
 **What does Jupyter geospatial look like in an era of coding agents?**
 
-Coding agents are "coming for all of us" -- the landscape **is** changing. How does this impact geospatial practitioners and how can we maximize the benefits and minimize the harms of this change?
+Coding agents are "coming for all of us" -- the landscape **is** changing.
+How does this impact geospatial practitioners and how can we maximize the benefits and minimize the harms of this change?
 
-Frontier AI organizations are putting forth a vision where the underlying software is diminished/hidden and the interface we use is a chatbot, and we're all locked us in to those interfaces. This is a less open future.
+Frontier AI organizations are putting forth a vision where the underlying software is diminished/hidden and the interface we use is a chatbot, and we're all locked us in to those interfaces.
+This is a less open future.
 
 
 ### Who is impacted by this problem?
 
 Everyone everywhere! In our community, geospatial practitioners, software engineers, students, instructors.
 
-* End-user of geospatial / GIS tools: students & researchers. Just want to achieve a goal or complete a task, don't care too much about what tool they use as long as it works. <how that might be disrupted>.
-* Developer community: open source & industry developer communities. <motivation>. <disruption>.
-* Open geospatial and AI communities: JupyterAI, JupyterGIS, Pangeo are our friends and neighbors that are likely to be impacted by this problem. Want to help people break out of "proprietary prisons". <disruption>.
+* End-user of geospatial / GIS tools: students & researchers.
+  Just want to achieve a goal or complete a task, don't care too much about what tool they use as long as it works.
+  <how that might be disrupted>.
+* Developer community: open source & industry developer communities.
+  <motivation>. <disruption>.
+* Open geospatial and AI communities: JupyterAI, JupyterGIS, Pangeo are our friends and neighbors that are likely to be impacted by this problem.
+  Want to help people break out of "proprietary prisons".
+  <disruption>.
 
 Jupyter as a platform is likely to be threatened by the emergence of new agentic geospatial platforms (Esri, Fused, Google Colab, ...) and generic agentic tools (Claude Code, ...).
 
-TODO: Needs more fleshing-out. Seek voices of people in each of the above buckets to help define these.
+TODO: Needs more fleshing-out.
+Seek voices of people in each of the above buckets to help define these.
 
 
 ### Proposed solution
@@ -36,9 +44,11 @@ TODO: Needs more fleshing-out. Seek voices of people in each of the above bucket
 We think the following values / practices are needed:
 
 * Small models supported by strong software infrastructure that enables them to compete with frontier models for some (?) tasks
-    * Engineering is needed to help these do geospatial well. Skills, tools, ???
+    * Engineering is needed to help these do geospatial well.
+      Skills, tools, ???
 * Interfaces that integrate with geospatial tools, e.g. JupyterGIS
-* People need to be better able to produce geospatial data, not just consume it. _TODO: Does this belong here or not? Separate initiative?_ (this is what excites @cboettig about Jed's vision for source.coop -- you can be a producer for geospatial data, not just Amazon, Esri, etc.)
+* People need to be better able to produce geospatial data, not just consume it.
+  _TODO: Does this belong here or not? Separate initiative?_ (this is what excites @gh:cboettig about Jed's vision for source.coop -- you can be a producer for geospatial data, not just Amazon, Esri, etc.)
 *
 
 ### Proposed implementation
@@ -52,7 +62,8 @@ TODO!!!
 
 * Leverages JupyterAI interfaces and contributors to the development of those interfaces
 * Integrates with JupyterGIS
-* Containers -- safe places for agents to go wild. How can JupyterHub enable this?
+* Containers -- safe places for agents to go wild.
+  How can JupyterHub enable this?
 * Safer agents (both financially and with respect to personal data / services)
 * Collaboration!
 
@@ -69,9 +80,9 @@ TODO!!!
 
 Fleshing this initiative out:
 
-- @kpdavi
-- @cboettig
-- @mfisher87
+- @gh:kpdavi
+- @gh:cboettig
+- @gh:mfisher87
 - Who else wants to help?
 
 Who's implementing stuff?
@@ -81,7 +92,7 @@ TODO -- are you inspired by any of these ideas? Comment below!
 
 ### Endorsements
 
-- @cboettig
+- @gh:cboettig
 
 
 ### Other information
@@ -90,7 +101,7 @@ TODO -- are you inspired by any of these ideas? Comment below!
 
 * https://boettiger-lab.github.io/jupyter-geoagent
 
-From @Mary-h86:
+From @gh:Mary-h86:
 
 * https://github.com/makeabilitylab/altgeoviz
-* MapStyle recommender: @Mary-h86 's idea where the user gives a prompt / explaining the intent and what they want to show and based on the data model and intent, the model recommends some styles
+* MapStyle recommender: @gh:Mary-h86 's idea where the user gives a prompt / explaining the intent and what they want to show and based on the data model and intent, the model recommends some styles

--- a/myst.yml
+++ b/myst.yml
@@ -3,6 +3,8 @@ version: 1
 project:
   title: "GeoJupyter Initiatives"
   github: &repo-url "https://github.com/geojupyter/initiatives"
+  plugins:
+    - "https://raw.githubusercontent.com/mfisher87/mystmd-plugin-github-user-mentions/refs/heads/main/src/index.mjs"
   toc:
     - file: "index.md"
     - title: "💡 Initiatives"
@@ -10,6 +12,7 @@ project:
         - pattern: "initiatives/[0-9]*-*/index.md"
     - title: "🗂️ Project board"
       url: "https://github.com/orgs/geojupyter/projects/6"
+
 site:
   template: "book-theme"
   actions:


### PR DESCRIPTION
An [official plugin](https://github.com/myst-contrib/myst-github) exists but it hits the GitHub API and therefore requires secrets to avoid rate limiting. Full list of tradeoffs in the README: https://github.com/mfisher87/mystmd-plugin-github-user-mentions

<!-- readthedocs-preview geojupyter-initiatives start -->
---
:mag: Preview: https://geojupyter-initiatives--47.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-initiatives end -->